### PR TITLE
Changed GCM warning message to config gcm_key

### DIFF
--- a/ionic-push.js
+++ b/ionic-push.js
@@ -29,7 +29,7 @@ function($http, $cordovaPush, $cordovaLocalNotification, $ionicApp, $ionicPushAc
     }
 
     if (!app.gcm_key) {
-      console.warn('PUSH: Unable to get GCM project number, run "ionic config set gcm_id your-gcm-id"');
+      console.warn('PUSH: Unable to get GCM project number, run "ionic config set gcm_key your-gcm-id"');
     }
   } else {
     console.warn('CORE: Unable to load app ID or API key, falling back to $ionicApp.getApp()...');


### PR DESCRIPTION
Updated GCM warning message to display "config set gcm_key your-gcm-key" as "config set gcm_id" returns unauthorized error.
