### PR TITLE
fix(): remove $cordovaLocalNotification from the dependencies

### DIFF
--- a/ionic-push.js
+++ b/ionic-push.js
@@ -9,9 +9,9 @@ angular.module('ionic.service.push', ['ngCordova', 'ionic.service.core'])
  * }])
  *
  */
-.factory('$ionicPush', ['$http', '$cordovaPush','$cordovaLocalNotification', '$ionicApp', '$ionicPushActions', '$ionicUser', '$ionicCoreSettings', '$rootScope', '$log', '$q',
+.factory('$ionicPush', ['$http', '$cordovaPush', '$ionicApp', '$ionicPushActions', '$ionicUser', '$ionicCoreSettings', '$rootScope', '$log', '$q',
 
-function($http, $cordovaPush, $cordovaLocalNotification, $ionicApp, $ionicPushActions, $ionicUser, $ionicCoreSettings, $rootScope, $log, $q) {
+function($http, $cordovaPush, $ionicApp, $ionicPushActions, $ionicUser, $ionicCoreSettings, $rootScope, $log, $q) {
 
   // Grab the current app
   var app = {}


### PR DESCRIPTION
`$cordovaLocalNotification` is not used within the `$ionicPush` factory. Furthermore, it isn’t mocked by `ngCordovaMocks`, so we can’t actually use this plugin without installing `cordova-local-notification` which is a bit sad…
