### PR TITLE
fixed the device token will display in iOS and Android token field when using Android

### DIFF
--- a/ionic-push.js
+++ b/ionic-push.js
@@ -148,7 +148,7 @@ function($http, $cordovaPush, $cordovaLocalNotification, $ionicApp, $ionicPushAc
 
         defer.resolve(token);
 
-        if(token !== 'OK') {
+        if(token !== 'OK' && ionic.Platform.isIOS()) {
 
           $rootScope.$emit('$cordovaPush:tokenReceived', {
             token: token,


### PR DESCRIPTION
When using the Android mobile, and register the device token to the `apps.ionic.io`, the registered device token will display in iOS and Android device token fields in user profile (`My Apps > Users > Android Mobile User`)

![screen shot 2015-09-09 at 12 31 51 am](https://cloud.githubusercontent.com/assets/322299/9740992/67108a7c-568a-11e5-90f6-b179365e1281.png)
